### PR TITLE
User 서비스 로그 모니터링 시스템 구축 테스트

### DIFF
--- a/monitoring/loki/loki-config.yml
+++ b/monitoring/loki/loki-config.yml
@@ -1,0 +1,50 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+# By default, Loki will send anonymous, but uniquely-identifiable usage and configuration
+# analytics to Grafana Labs. These statistics are sent to https://stats.grafana.org/
+#
+# Statistics help us better understand how Loki is used, and they show us performance
+# levels for most users. This helps us prioritize features and documentation.
+# For more information on what's sent, look at
+# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go
+# Refer to the buildReport method to see what goes into a report.
+#
+# If you would like to disable reporting, uncomment the following lines:
+#analytics:
+#  reporting_enabled: false

--- a/user/build.gradle
+++ b/user/build.gradle
@@ -28,6 +28,11 @@ ext {
 }
 
 dependencies {
+	// monitoring
+	implementation 'com.github.loki4j:loki-logback-appender:1.5.1'
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
 	// email
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/user/src/main/java/com/sparta/hotdeal/user/application/exception/GlobalExceptionHandler.java
+++ b/user/src/main/java/com/sparta/hotdeal/user/application/exception/GlobalExceptionHandler.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
-@Slf4j(topic = "AuthExceptionHandler")
+@Slf4j(topic = "UserExceptionHandler")
 public class GlobalExceptionHandler {
 
     @ExceptionHandler({IllegalArgumentException.class})
@@ -30,6 +30,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<RestApiException> handleValidationExceptions(MethodArgumentNotValidException ex) {
         StringBuilder errorMessages = new StringBuilder();
+
+        log.warn(ex.getMessage());
 
         ex.getBindingResult().getFieldErrors().forEach(error ->
                 errorMessages.append(error.getField())

--- a/user/src/main/resources/logback.xml
+++ b/user/src/main/resources/logback.xml
@@ -1,0 +1,17 @@
+<configuration>
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>http://localhost:3100/loki/api/v1/push</url>
+        </http>
+        <format>
+            <label>
+                <pattern>app=my-app,host=${HOSTNAME}</pattern>
+            </label>
+            <message class="com.github.loki4j.logback.JsonLayout" />
+        </format>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="LOKI" />
+    </root>
+</configuration>


### PR DESCRIPTION
### PR 타입
- [x] 기능 추가
- [ ] 리팩토링
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- feature/105/monitoring-grafana -> develop
### 이슈
- #105 
### Description
- User 서비스 loki, prometheus, actuacotr 의존성 추가
- loki 관련 설정파일 작성
- Grafana 대시보드 생성
![image](https://github.com/user-attachments/assets/3841c2ea-9813-4c4c-a4e2-3792e836c32b)

### To Reviewers
- User 서비스에 대해 로그 모니터링 시스템과 대시보드를 구축했습니다.
- 현재는 WARN 이상 레벨의 로그만 가져오도록 설정되어 있습니다.
- 이후 다른 서비스까지 전체 적용 예정입니다.
