### PR TITLE
Company 목록 조회 시 쿼리파라미터 및 인덱싱 추가

### DIFF
--- a/company/src/main/java/com/sparta/hotdeal/company/application/service/CompanyService.java
+++ b/company/src/main/java/com/sparta/hotdeal/company/application/service/CompanyService.java
@@ -78,8 +78,13 @@ public class CompanyService {
                 .build();
     }
 
-    public Page<ResGetCompanyByIdDto> getCompanyList(Pageable pageable) {
-        Page<Company> companyPage = companyRepository.findAll(pageable);
-        return companyPage.map(ResGetCompanyByIdDto::create);
+    public Page<ResGetCompanyByIdDto> getCompanyList(Pageable pageable, CompanyStatusEnum status) {
+        if (status != null) {
+            return companyRepository.findByStatus(status, pageable)
+                    .map(ResGetCompanyByIdDto::create);
+        } else {
+            return companyRepository.findAll(pageable)
+                    .map(ResGetCompanyByIdDto::create);
+        }
     }
 }

--- a/company/src/main/java/com/sparta/hotdeal/company/domain/entity/company/Company.java
+++ b/company/src/main/java/com/sparta/hotdeal/company/domain/entity/company/Company.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Index;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -23,7 +24,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(access = AccessLevel.PRIVATE)
-@Table(name = "p_companies")
+@Table(name = "p_companies", indexes = @Index(name = "idx_business_registration_number", columnList = "businessRegistrationNumber"))
 public class Company extends Audit {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)

--- a/company/src/main/java/com/sparta/hotdeal/company/domain/repository/CompanyRepository.java
+++ b/company/src/main/java/com/sparta/hotdeal/company/domain/repository/CompanyRepository.java
@@ -1,6 +1,8 @@
 package com.sparta.hotdeal.company.domain.repository;
 
 import com.sparta.hotdeal.company.domain.entity.company.Company;
+import com.sparta.hotdeal.company.domain.entity.company.CompanyStatusEnum;
+import java.nio.channels.FileChannel;
 import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
@@ -16,4 +18,6 @@ public interface CompanyRepository {
     Optional<Company> findById(UUID id);
 
     Page<Company> findAll(Pageable pageable);
+
+    Page<Company> findByStatus(CompanyStatusEnum status, Pageable pageable);
 }

--- a/company/src/main/java/com/sparta/hotdeal/company/presentation/controller/CompanyController.java
+++ b/company/src/main/java/com/sparta/hotdeal/company/presentation/controller/CompanyController.java
@@ -26,6 +26,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -79,7 +80,8 @@ public class CompanyController {
     @Secured({"ROLE_SELLER", "ROLE_MASTER", "ROLE_MANAGER"})
     @Operation(summary = "업체 목록 조회 API", description = "업체 목록을 조회합니다.")
     public ResponseDto<Page<ResGetCompanyByIdDto>> getCompanyList(
-            @AuthenticationPrincipal RequestUserDetails userDetails, Pageable pageable) {
-        return ResponseDto.of("업체목록이 조회되었습니다.", companyService.getCompanyList(pageable));
+            @AuthenticationPrincipal RequestUserDetails userDetails, Pageable pageable,
+            @RequestParam(required = false) CompanyStatusEnum status) {
+        return ResponseDto.of("업체목록이 조회되었습니다.", companyService.getCompanyList(pageable, status));
     }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- refactor/115/refactor-company
### 이슈
- Resolves #115 
### Description
- 목록 조회 시 인덱싱을 추가해 조회 성능을 개선했습니다.
- 쿼리파라미터로 status를 받아, 상태에 따른 필터 + 페이징 처리를 했습니다.
#### /api/v1/companies/{companyId}
- 인덱싱은 "데이터가 고유한" 칼럼에 적용하는 것이 효율이 좋다고하여 unique하게 관리되는 업체등록번호를 인덱싱했습니다.
- @Table 어노테이션에 지정하므로 사용할 수 있습니다.
#### 테스트 컨디션
- 쓰레드들 수: 100
- ramp-up: 1
- 루프 카운트: 10
- DB 내 데이터 개수: 20002개
- 20002개 중 20000번째 데이터를 단건 조회하는 케이스입니다.
  - [인덱싱 미추가]

  - ![스크린샷 2025-01-16 오후 2 57 41](https://github.com/user-attachments/assets/25f6e573-a7c4-4847-b386-289b6028e5e2)

  - [인덱싱 추가]

  - ![스크린샷 2025-01-16 오후 2 52 36](https://github.com/user-attachments/assets/c0f7cba3-d567-4ee9-af70-25174e0cb7ab)

- 전반적인 조회 시 평균 시간, 최댓값, 표준 편차가 인덱싱 적용 후 개선된걸 확인할 수 있습니다.

### To Reviewers
- 리뷰받고 싶은 부분에 대해 작성
