### PR TITLE
Gateway 필터를 수행하지 않을 경로를 Enum으로 관리하도록 변경

### DIFF
--- a/gateway/src/main/java/com/sparta/hotdeal/gateway/filter/AllowedPath.java
+++ b/gateway/src/main/java/com/sparta/hotdeal/gateway/filter/AllowedPath.java
@@ -1,0 +1,31 @@
+package com.sparta.hotdeal.gateway.filter;
+
+import java.util.EnumSet;
+
+public enum AllowedPath {
+    SWAGGER("/swagger-ui/", "*"),
+    API_DOCS("/v3/api-docs", "*"),
+    AUTH("/api/v1/auth", "*"),
+    PAYMENT("/payment/", "*"),
+    PRODUCTS("/api/v1/products", "GET"),
+    PROMOTIONS("/api/v1/promotions", "GET"),
+    REVIEWS("/api/v1/reviews", "GET");
+
+    private final String path;
+    private final String method;
+
+    AllowedPath(String path, String method) {
+        this.path = path;
+        this.method = method;
+    }
+
+    public static boolean isAllowed(String requestPath, String requestMethod) {
+        return EnumSet.allOf(AllowedPath.class).stream()
+                .anyMatch(allowedPath -> allowedPath.matches(requestPath, requestMethod));
+    }
+
+    private boolean matches(String requestPath, String requestMethod) {
+        return requestPath.startsWith(this.path) &&
+                ("*".equals(this.method) || this.method.equalsIgnoreCase(requestMethod));
+    }
+}

--- a/gateway/src/main/java/com/sparta/hotdeal/gateway/filter/AuthenticationFilter.java
+++ b/gateway/src/main/java/com/sparta/hotdeal/gateway/filter/AuthenticationFilter.java
@@ -21,7 +21,7 @@ public class AuthenticationFilter implements GlobalFilter {
         String path = exchange.getRequest().getURI().getPath();
         String method = exchange.getRequest().getMethod().name();
 
-        if (checkRequestIsNotRequireFilter(path, method)) {
+        if (AllowedPath.isAllowed(path, method)) {
             return chain.filter(exchange);
         }
 
@@ -44,40 +44,5 @@ public class AuthenticationFilter implements GlobalFilter {
                 .build();
 
         return chain.filter(exchange);
-    }
-
-    // 추후 리팩토링 진행
-    private boolean checkRequestIsNotRequireFilter(String path, String method) {
-        //swagger 경로
-        if (path.startsWith("/swagger-ui/") || path.startsWith("/v3/api-docs")) {
-            return true;
-        }
-
-        // auth 경로
-        if (path.startsWith("/api/v1/auth")) {
-            return true;
-        }
-
-        // payment view 경로
-        if (path.startsWith("/payment/")) {
-            return true;
-        }
-
-        // product 경로
-        if (path.startsWith("/api/v1/products") && method.equalsIgnoreCase("GET")) {
-            return true;
-        }
-
-        // promotion 경로
-        if (path.startsWith("/api/v1/promotions") && method.equalsIgnoreCase("GET")) {
-            return true;
-        }
-
-        // review 경로
-        if (path.startsWith("/api/v1/reviews") && method.equalsIgnoreCase("GET")) {
-            return true;
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
### PR 타입
- [ ] 기능 추가
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
### 반영 브랜치
- refactor/133/filter-url-gateway -> develop
### 이슈
- Resolves #133 
### Description
- Gateway 필터를 수행하지 않을 경로를 Enum으로 분리
### To Reviewers
- Enum으로 필터를 수행하지 않을 경로들을 관리하며, 추가 경로가 필요하다면 enum의 필드만 추가하면 됩니다.
- 요청 경로와 enum의 경로가 일치하는지 체크하는 메서드를 enum 내부에 함께 작성했습니다.
- Gateway의 AuthenticationFilter에서는 enum의 메서드를 호출합니다.